### PR TITLE
Remove hyphen from 'je-themes' string and add auto enable on first install

### DIFF
--- a/jethemes.xml
+++ b/jethemes.xml
@@ -34,7 +34,7 @@
 	</languages>
 
 	<updateservers>
-		<server type="extension" name="jethemes">https://web-eau.net/files/jethemes/jethemes.xml</server>
+		<server type="extension" name="jethemes">https://web-eau.net/files/je-themes/je-themes.xml</server>
 	</updateservers>
 	<scriptfile>script.php</scriptfile>
 </extension>

--- a/jethemes.xml
+++ b/jethemes.xml
@@ -2,7 +2,7 @@
 <extension type="plugin" group="installer" method="upgrade">
 
 	<name>plg_installer_templatejoomla</name>
-    <element>je-themes</element>
+    <element>jethemes</element>
 	<author>web-eau-net</author>
 	<version>1.0.0</version>
 	<creationDate>2025-08</creationDate>
@@ -15,12 +15,13 @@
 	<namespace path="src">Joomla\Plugin\Installer\Templatejoomla</namespace>
 
 	<files>
-		<folder plugin="je-themes">services</folder>
+		<folder plugin="jethemes">services</folder>
 		<folder>src</folder>
 		<folder>tmpl</folder>
+		<filename>script.php</filename>
 	</files>
 
-	<media folder="media" destination="plg_installer_je-themes">
+	<media folder="media" destination="plg_installer_jethemes">
 		<folder>js</folder>
 		<folder>css</folder>
 	</media>
@@ -33,7 +34,7 @@
 	</languages>
 
 	<updateservers>
-		<server type="extension" name="je-themes">https://web-eau.net/files/je-themes/je-themes.xml</server>
+		<server type="extension" name="jethemes">https://web-eau.net/files/jethemes/jethemes.xml</server>
 	</updateservers>
-
+	<scriptfile>script.php</scriptfile>
 </extension>

--- a/script.php
+++ b/script.php
@@ -1,0 +1,42 @@
+<?php
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Installer\InstallerScript;
+use Joomla\CMS\Factory;
+
+class PlginstallerJethemesInstallerScript extends InstallerScript
+{
+
+    public function postflight($type, $parent)
+    {
+        // check if it's an install, not an update
+        if ($type == 'install') {
+            $this->enablePlugin();
+        }
+    }
+
+    /**
+     * Publish the plugin after installatio
+     */
+    private function enablePlugin()
+    {
+        $db = Factory::getDbo();
+        $query = $db->getQuery(true);
+        
+        $query->update('#__extensions')
+              ->set($db->quoteName('enabled') . ' = 1')
+              ->where($db->quoteName('element') . ' = ' . $db->quote('jethemes'))
+              ->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
+              ->where($db->quoteName('folder') . ' = ' . $db->quote('installer'));
+        
+        $db->setQuery($query);
+        
+        try {
+            $db->execute();
+            Factory::getApplication()->enqueueMessage('Plugin activé automatiquement', 'message');
+        } catch (Exception $e) {
+            Factory::getApplication()->enqueueMessage('Erreur lors de l\'activation du plugin: ' . $e->getMessage(), 'error');
+        }
+    }
+}
+?>


### PR DESCRIPTION
It seems using hyphen in element's name for plugins is not allowed and script class can't be detected due somehow the hyphen is not cleared from class name (which is invalid for a PHP class). In my proposal I use 'jethemes' instead. It auto enable plugin on first install. If you have the plugin previously installed it won't trigger the auto enable action.

Suggestion in case this PR is approved: adjust update server URL for consistency by removing hyphen from 'je-themes'.